### PR TITLE
Add a link in the Summary to the Docker deployment

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -46,6 +46,7 @@
    * [Volt Helpers](docs/volt_helpers.md)
 * [Deployment](deployment/README.md)
    * [Heroku](deployment/heroku.md)
+   * [Docker](deployment/docker.md)
 * [Getting Help](getting_help/README.md)
 * [FAQ](getting_help/faq.md)
 * [Contributing](contributing/README.md)


### PR DESCRIPTION
I've forgot to add a link in the summary to the Docker deployment instructions with PR #17. Sorry.