### PR TITLE
first run add of source code links to documentation

### DIFF
--- a/en/docs/buffers.md
+++ b/en/docs/buffers.md
@@ -36,3 +36,5 @@ Because the store collection is automatically synced to the backend, any change 
 ```
 
 Calling .buffer on an existing model will return a buffer for that model instance.  If you call .buffer on a Volt::ArrayModel (plural sub-collection), you will get a buffer for a new item in that collection.  Calling .save! will then add the item to that sub-collection as if you had done << to push the item into the collection.
+
+More on buffers can be found in the [source code](https://github.com/voltrb/volt/blob/master/lib/volt/models/buffer.rb).

--- a/en/docs/channel.md
+++ b/en/docs/channel.md
@@ -9,3 +9,5 @@ Controllers provide a `#channel` method, that you can use to get the status of t
 | error       | the error message for the last failed connection          |
 | retry_count | the number of reconnection attempts that have been made without a successful connection |
 | reconnect_interval | the time until the next reconnection attempt (in seconds) |
+
+More can be found in the [source code](https://github.com/voltrb/volt/blob/master/lib/volt/page/channel.rb).

--- a/en/docs/fields.md
+++ b/en/docs/fields.md
@@ -21,3 +21,5 @@ new_post.title
 
 store._posts << new_post
 ```
+
+More on field helpers can be found in the [source code](http://www.github.com/voltrb/volt/blob/master/lib/volt/models/field_helpers.rb).

--- a/en/docs/model_classes.md
+++ b/en/docs/model_classes.md
@@ -22,3 +22,5 @@ Now when you access any sub-collection called ```_info```, it will load as an in
 ```
 
 This lets you set custom methods and validations within collections.
+
+More on models can be found in the [source code](http://www.github.com/voltrb/volt/tree/master/lib/volt/models/).

--- a/en/docs/reactive_accessors.md
+++ b/en/docs/reactive_accessors.md
@@ -9,3 +9,5 @@ The default ModelController proxies any missing methods to its model.  Sometimes
 ```
 
 Now from the view we can bind to query while also changing in and out the model.  You can also use ```reactive_reader``` and ```reactive_writer```. When query is accessed it tracks that it was accessed and will any Computations when it changes.
+
+More on reactive accessors can be found in the [source code](http://www.github.com/voltrb/volt/blob/master/lib/volt/reactive/reactive_accessors.rb).

--- a/en/docs/routes.md
+++ b/en/docs/routes.md
@@ -3,3 +3,5 @@
 Routes in Volt are very different from traditional backend frameworks.  Since data is synchronized using websockets, routes are mainly used to serialize the state of the application into the url in a pretty way.  When a page is first loaded, the URL is parsed with the routes and the params model's values are set from the URL.  Later if the params model is updated, the URL is updated based on the routes.
 
 This means that routes in Volt have to be able to go both from URL to params and params to URL.  It should also be noted that if a link is clicked and the controller/view to render the new URL is within the current component (or an included component), the page will not be reloaded, the URL will be updated with the HTML5 history API, and the params hash will reflect the new URL.  You can use the changes in params to render different views based on the URL.
+
+More can be found on routes and the router in the [source code](http://www.github.com/voltrb/volt/tree/master/lib/volt/router).

--- a/en/docs/tasks.md
+++ b/en/docs/tasks.md
@@ -35,3 +35,7 @@ You can use the ```#then``` method of the returned promise to get the result of 
     end
 ```
 
+You can see more on tasks in the source code files.
+[1](http://www.github.com/voltrb/volt/tree/master/lib/volt/tasks),
+
+[2](http://www.github.com/voltrb/volt/tree/master/app/volt/tasks)

--- a/en/docs/template_bindings.md
+++ b/en/docs/template_bindings.md
@@ -63,3 +63,4 @@ The above would search the following:
 
 Once the view file for the control or template is found, it will look for a matching controller.  If the template file does not have an associated controller, a ```ModelController``` will be used.  Once a controller is found and loaded, a corresponding "action" method will be called on it if its exists.  Action methods default to "index" unless the component or template path has two parts, in which case the last part is the action.
 
+You can see more on template bindings in the [source code](http://www.github.com/voltrb/volt/blob/master/lib/volt/page/bindings/template_binding.rb).

--- a/en/docs/url_for_and_url_with.md
+++ b/en/docs/url_for_and_url_with.md
@@ -27,3 +27,9 @@ Because url_for is a controller method, it can also be accessed in views.
 ```html
 <a href="{{ url_with(page: 5) }}">page 5</a>
 ```
+
+You can see more on `url_for` and `url_with` in the source code files:
+
+[1](https://github.com/voltrb/volt/blob/master/lib/volt/controllers/model_controller.rb),
+
+[2](https://github.com/voltrb/volt/blob/master/lib/volt/models/url.rb)

--- a/en/docs/users.md
+++ b/en/docs/users.md
@@ -72,3 +72,5 @@ end
 ```
 
 You can use [volt-fields](https://github.com/voltrb/volt-fields) to show any errors when creating a user.
+
+You can find more on users in the [source code](http://www.github.com/voltrb/volt/tree/master/app/volt/models/user.rb).

--- a/en/docs/validations.md
+++ b/en/docs/validations.md
@@ -18,3 +18,5 @@ When calling save on a model with validations, the following occurs:
     - re-running the validations on the server side makes sure that no data can be saved that doesn't pass the validations
 3. If all validations pass, the data is saved to the database and the promise resolved on the client.
 4. The data is synced to all other clients.
+
+More on validations can be found in the [source code](http://www.github.com/voltrb/volt/tree/master/lib/volt/models/validations.rb).

--- a/en/docs/views.md
+++ b/en/docs/views.md
@@ -19,3 +19,5 @@ In Volt, views are written in a simple template language where ruby can be inser
 While we use the controller terminology, Volt is closer to a MVVM framework.  Any method call or instance variable lookup runs in the context of a controller.  The controller
 
 If you have a view at ```app/home/views/index/index.html``` it will load the controller at ```app/home/controller/index_controller.rb```.
+
+More on bindings can be found in the [source code](http://www.github.com/voltrb/volt/tree/master/lib/volt/page/bindings).


### PR DESCRIPTION
In the format of:
```
...
You can find more about X in the [source_code](link)
```
for single source directories or files, and
```
You can find more about X in the source code files
[1](link),
[2](link)
```
for multiple