### PR TITLE
add config to set environment to production on Heroku

### DIFF
--- a/en/deployment/heroku.md
+++ b/en/deployment/heroku.md
@@ -29,3 +29,7 @@ else
   config.db_port = 27017
 end
 ```
+
+Set Volt environment on Heroku to production.
+
+    $ heroku config:add VOLT_ENV='production'


### PR DESCRIPTION
volt looks for ENV['VOLT_ENV']
heroku has ENV['RACK_ENV'] set to 'production'