### PR TITLE
Remove trailing slashes from opening nav tags in tutorial code.

### DIFF
--- a/en/tutorial/a_sample_todo_app.md
+++ b/en/tutorial/a_sample_todo_app.md
@@ -47,9 +47,9 @@ And then add a `/todos` link to the navbar, which is rendered from `app/main/vie
   <div class="container">
     <div class="header">
       <ul class="nav nav-pills pull-right">
-        <:nav href="/" text="Home" />
-        <:nav href="/todos" />Todos</:nav> <!-- New link -->
-        <:nav href="/about" />About</:nav>
+        <:nav href="/">Home</:nav>
+        <:nav href="/todos">Todos</:nav> <!-- New link -->
+        <:nav href="/about">About</:nav>
       </ul>
 ...
 ```

--- a/en/tutorial/todo_functionality.md
+++ b/en/tutorial/todo_functionality.md
@@ -20,7 +20,7 @@ Obviously, our todo list also needs to be able to monitor which items have been 
 <tr>
   <td><input type="checkbox" checked="{{ todo._completed }}" /></td>
   <td class="{{ if todo._completed }}complete{{ end }}">{{ todo._name }}</td>
-  <td><button e-click="remove_todo(todo)">X</button></td>
+  <td><button e-click="todo.destroy">X</button></td>
 </tr>
 ...
 ```

--- a/ja/tutorial/a_sample_todo_app.md
+++ b/ja/tutorial/a_sample_todo_app.md
@@ -49,9 +49,9 @@ bundle exec volt server
   <div class="container">
     <div class="header">
       <ul class="nav nav-pills pull-right">
-        <:nav href="/" text="Home" />
-        <:nav href="/todos" text="Todos" /> <!-- New link -->
-        <:nav href="/about" text="About" />
+        <:nav href="/">Home</:nav>
+        <:nav href="/todos">Todos</:nav> <!-- New link -->
+        <:nav href="/about">About</:nav>
       </ul>
 ...
 ```


### PR DESCRIPTION
* Trailing slashes in opening nav tags break the page rendering. Looks like they
were a copy-paste error.
* Switched to use a consistent markup style for the tabs so they match what's being generated.
* Removed references to remove_todo controller method in the EN version.

TODO Remove references to remove_todo in the JP version. I don't know Japanese so I've not touched that.