### PR TITLE
Update faq.md (broken links)

### DIFF
--- a/en/getting_help/faq.md
+++ b/en/getting_help/faq.md
@@ -1,4 +1,4 @@
 # FAQ
 
-* [What runs on the Client vs Server?](getting_help/what_runs_on_the_client_vs_server.md)
-* [Can I use jQuery? (or other DOM manipulating JS)](getting_help/can_i_use_jquery_or_other_dom_manipulating_js.md)
+* [What runs on the Client vs Server?](what_runs_on_the_client_vs_server.md)
+* [Can I use jQuery? (or other DOM manipulating JS)](can_i_use_jquery_or_other_dom_manipulating_js.md)


### PR DESCRIPTION
Found some broken links on the FAQ. Was just a typo in the markdown. Here's the fix.