### PR TITLE
Fix typo on todo_functionality.md

### DIFF
--- a/en/tutorial/todo_functionality.md
+++ b/en/tutorial/todo_functionality.md
@@ -174,7 +174,7 @@ def incomplete
 end
 
 def percent_complete
-  _todos.size then do |size|
+  _todos.size.then do |size|
     completed.then do |completed|
       (completed / size.to_f * 100).round
     end

--- a/ja/tutorial/todo_functionality.md
+++ b/ja/tutorial/todo_functionality.md
@@ -175,7 +175,7 @@ def incomplete
 end
 
 def percent_complete
-  _todos.size then do |size|
+  _todos.size.then do |size|
     completed.then do |completed|
       (completed / size.to_f * 100).round
     end


### PR DESCRIPTION
it changes `_todos.size then do |size|` to `_todos.size.then do |size|`