### PR TITLE
improve and move the yield binding

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -12,7 +12,6 @@
        * [Each Binding](docs/each_binding.md)
        * [Attribute Bindings](docs/attribute_bindings.md)
        * [View Bindings](docs/view_bindings.md)
-       * [Yield Binding](docs/yield_binding.md)
        * [Escaping](docs/escaping.md)
        * [Event Bindings](docs/event_bindings.md)
    * [Models](docs/models.md)
@@ -45,6 +44,7 @@
        * [Provided Components](docs/provided_components.md)
    * [Tags](docs/tags.md)
        * [Tag Arguments/Attributes](docs/tag_attributes.md)
+       * [Yield Binding in Tags](docs/yield_binding.md)
        * [Tag Events and Triggering](docs/tag_events_and_triggering.md)
    * [Routes](docs/routes.md)
        * [Routes File](docs/routes_file.md)
@@ -74,4 +74,3 @@
    * [Does Volt support Haml, Slim, etc...](getting_help/does_volt_support_haml,_slim,_etc.md)
 * [Component Gems](contributing/component_gems.md)
 * [Contributing](contributing/README.md)
-

--- a/en/docs/tag_attributes.md
+++ b/en/docs/tag_attributes.md
@@ -1,6 +1,6 @@
 # Tag Arguments/Attributes
 
-Like other html tags, Volt tags can be passed attributes.  These attributes are then converted into an object that is passed as the first argument to the initialize method of the controller.  The standard Volt::ModelController's initialize will then assign the object to the ```attrs``` property which can be accessed with ```#attrs```.  This makes it easy to access attributes passed in.
+Like other html tags, Volt tags can be passed attributes.  These attributes are then converted into an object that is passed  to the initialize method of the controller.  The standard Volt::ModelController's initialize will then assign the object to the ```attrs``` property which can be accessed with ```#attrs```.  This makes it easy to access attributes passed in.
 
 ```html
 <:Body>

--- a/en/docs/tags.md
+++ b/en/docs/tags.md
@@ -16,6 +16,9 @@ or
 
 Refer to the View Binding section to see how tags lookup their associated view files.  The above has the same lookup as ```{{ template "tag_name" }}```.  Doing ```<:blog:comments />``` is the same as ```{{ template "blog/comments" }}```
 
-A tag loads the same as a template, loading the controller, calling the action method (if one exists), and rendering the view.  You can also pass in attributes to Tags.
+A tag loads the same as a template, loading the controller, calling the action method (if one exists), and rendering the view.  In the next subchapters you will learn to:
 
+  - Pass attributes into tags
+  - yield inside tags
+  - trigger events in tags and handle them.
 

--- a/en/docs/yield_binding.md
+++ b/en/docs/yield_binding.md
@@ -1,20 +1,39 @@
 # Yield Binding
 
-When using [Tags](#tags), content can be passed between tags as follows:
+When using [Tags](#tags), content that is generated in the caller, can be passed into the tag definition.
+In other words the tag definition can refer to content of the caller, which has the same logic as
+a yield in ruby, but is slightly different. The simple example below demonstrates.
+
+Say you had a navigation element that you wanted to reuse, a simple list item like:
+
+```html
+<li>
+    <a href="/about">
+      <span class="nav_element"> About </span>
+    </a>
+</li>
+```
+
+This can be turned into tag easily and we could pass both link and text in with the  ```attrs```
+approach shown. But this would be clumsy for the span element, and can be achieved much better
+with the yield binding:
+
+```html
+<:Nav>
+    <li>
+        <a href="{{ attrs.href }}">
+            <span class="nav_element"> {{ yield }} </span>
+        </a>
+    </li>
+```
+
+To use this tag to create the output in the beginning of the page, you would write the following:
 
 ```html
 <:nav href="/about">About</:nav>
 ```
 
-In the example above, "About" can be rendered elsewhere using ```{{ yield }}```.  Here's an example using a tag to render a section.
-
-```html
-<:Nav>
-    <li>
-        <a href="{{ attrs.href }}">{{ yield }}</a>
-    </li>
-```
-
-Any content or other bindings can be passed into the ```tag```.  You can also pass content to component tags and yield inside of their views.
+In the example above, "About" will be rendered in the place of ```{{ yield }}```.
+In general, any content that is inside the calling tag will be rendered in place of ```yield``.
 
 Lastly if you just want to get the html content as a string, you can call ```yield_html``` in the controller.  This will return a string that you can ```.watch!``` on if needed and it will re-render when the content changes.


### PR DESCRIPTION
And smaller correction for tags.

Also moved the yield binding to the tags section, as it was having to explain what tags were before, just to explain what yield is.
Now the section is after the attribute section, so tags and attribute passing is already explained. 